### PR TITLE
Runtime optimizations for sentience and WR simulations

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@ Public version of Rethink Priorities' Moral Weight Project welfare range and sen
 
 This includes Monte-Carlo simulations to estimate the welfare range variances across models and species for the moral weight project.
 
-If you want to test the model with your own parameters, run "run.py" and follow the instructions in your terminal. The simulations take about 15 minutes to complete. Then run "sentience_models.ipynb" and then "wr_models.ipynb" to calculate the probabilities of sentience and welfare ranges and on pre-generated simulation data.
+If you want to test the model with your own parameters, run "run.py" and follow the instructions in your terminal. The simulations take about 4 minutes to complete. Then run "sentience_models.ipynb" and then "wr_models.ipynb" to calculate the probabilities of sentience and welfare ranges and on pre-generated simulation data.
 
 If you don't want to change the parameters, run "sentience_models.ipynb" and then "wr_models.ipynb" to calculate the probabilities of sentience and welfare ranges and on pre-generated simulation data.

--- a/sent_simulate.py
+++ b/sent_simulate.py
@@ -82,10 +82,16 @@ for s in range(N_SCENARIOS):
         else:
             print('... Completed {}/{}'.format(s + 1, N_SCENARIOS))
 
-    for idx, row in species_scores.iterrows():
-        proxy = row['proxies']
+    #Set up for iteration over proxies                
+    bern_probs = []
+    proxies_arr = []
+    num_proxies = len(species_scores)
+    judgements = species_scores[SPECIES]
+    
+    for ii in range(0,num_proxies):
+        proxy = species_scores.proxies[ii]
 
-        judgment = row[SPECIES]
+        judgment = judgements[ii]
         judgment = judgment.lower()
 
 
@@ -95,15 +101,25 @@ for s in range(N_SCENARIOS):
             lower_prob = judgment_prob_map[judgment]['lower']
             upper_prob = judgment_prob_map[judgment]['upper']
             proxy_prob = random.uniform(lower_prob, upper_prob)
-                
-        has_proxy = stats.bernoulli.rvs(proxy_prob)
+            
+        bern_probs.append(proxy_prob)
+        proxies_arr.append(proxy)
+
+    #Obtain bernoulli draws         
+    draws = stats.bernoulli.rvs(bern_probs,size=len(bern_probs))
+    
+    #Store bernoulli draw results        
+    for ii in range(0,num_proxies):
+        proxy = proxies_arr[ii]  
+        has_proxy = draws[ii]
         if proxy in hc_proxies:
             score = HC_WEIGHT*has_proxy
         else:
             score = has_proxy
+            
         simulated_probs[proxy].append(proxy_prob)
         simulated_scores[proxy].append(score)
-
+            
 
 if SAVE:
     print('... Saving 1/1')

--- a/wr_simulate.py
+++ b/wr_simulate.py
@@ -117,8 +117,15 @@ for s in range(N_SCENARIOS):
         else:
             print('... Completed {}/{}'.format(s + 1, N_SCENARIOS))
 
-    for idx, row in species_scores.iterrows():
-        proxy = row['proxies']
+    #Set up for iteration over proxies
+    num_proxies = len(species_scores)
+    bern_probs = []
+    proxies_arr = []
+    judgements = species_scores[SPECIES]    
+    
+    #Iterate over proxies
+    for ii in range(0,num_proxies):
+        proxy = species_scores.proxies[ii]
 
         if SPECIES in SENT_SPECIES and proxy in overlap_dict.keys():
             sent_proxies = overlap_dict[proxy]
@@ -140,7 +147,7 @@ for s in range(N_SCENARIOS):
             avg_score = a/count
             simulated_scores[proxy].append(avg_score)
         else:
-            judgement = row[SPECIES]
+            judgement = judgements[ii]
 
             if judgement == 'unknown':
                 proxy_prob = judgment_prob_map[judgement]
@@ -148,14 +155,25 @@ for s in range(N_SCENARIOS):
                 lower_prob = judgment_prob_map[judgement]['lower']
                 upper_prob = judgment_prob_map[judgement]['upper']
                 proxy_prob = random.uniform(lower_prob, upper_prob)
-                
-            has_proxy = stats.bernoulli.rvs(proxy_prob)
-            if proxy in hc_proxies:
-                score = HC_WEIGHT*has_proxy
-            else:
-                score = has_proxy
-            simulated_probs[proxy].append(proxy_prob)
-            simulated_scores[proxy].append(score)
+            bern_probs.append(proxy_prob)
+            proxies_arr.append(proxy)
+    
+    #Obtain bernoulli draws 
+    num_non_sent_proxies = len(bern_probs)
+    draws = stats.bernoulli.rvs(bern_probs,size=num_non_sent_proxies)
+    
+    #Store bernoulli draw results
+    for ii in range(0,num_non_sent_proxies):
+
+        proxy = proxies_arr[ii]  
+        has_proxy = draws[ii]
+        if proxy in hc_proxies:
+            score = HC_WEIGHT*has_proxy
+        else:
+            score = has_proxy
+        simulated_probs[proxy].append(proxy_prob)
+        simulated_scores[proxy].append(score)
+
 
 if SAVE:
     print('... Saving 1/1')


### PR DESCRIPTION
Optimized sentience and WR simulations to reduce runtime. Changes:

- Replaced use of iterrows with standard for loops
- Consolidated calls to stats.bernoulli.rvs by calling with a list of probabilities rather than making separate calls for each probability

All tests passed:

Sentience: 

> ### Testing to make sure score generation works ###
> All proxies with zero/one probabilities have scores equal to their expected values
> Number proxies whose proportion was outside 95% CI: 25
> Proportion of total proxies whose mean score was outside of the 95% CI: 0.046
> Probability of getting > 25/542 proxies outside of their 95% CI: 0.613
> Pass Test: 
> True
>
> test_one_species_birch_est (__main__.BirchModelTests) ... ok
> test_one_species_birch_sum (__main__.BirchModelTests) ... ok
> test_proxies (__main__.BirchModelTests) ... ok
> test_get_sum (__main__.TestSimpleFunctions) ... ok
> test_one_sim_p_sent_priors_based (__main__.TestSimpleFunctions) ... ok
> test_proxies (__main__.TestSimpleFunctions) ... ok
> 
> ----------------------------------------------------------------------
> Ran 6 tests in 2.217s
> 
> OK


Welfare Range: 

> All proxies with zero/one probabilities have scores equal to their expected values
> Number proxies whose proportion was outside 95% CI: 10
> Proportion of total proxies whose mean score was outside of the 95% CI: 0.042
> Probability of getting > 10/239 proxies outside of their 95% CI: 0.653
> Pass Test:
> True
> 
> test_one_sim_relative_score (__main__.TestComplexFuctions) ... ok
> test_one_sim_welare_range_2 (__main__.TestComplexFuctions) ... ok
> test_one_species_wr_2 (__main__.TestComplexFuctions) ... ok
> test_check_multiplication (__main__.TestMultiplication) ... ok
> test_filter_proxies (__main__.TestSimpleFunctions) ... ok
> test_one_sim_wr (__main__.TestSimpleFunctions) ... ok
> test_proxies (__main__.TestSimpleFunctions) ... ok
> 
> ----------------------------------------------------------------------
> Ran 7 tests in 2.466s
> 
> OK

Results unchanged (other than typical run-to-run statistical variation). Below comparison shows most recent post change run (left) vs. report (right)
<img width="1294" alt="Screenshot 2023-02-27 at 7 04 04 PM" src="https://user-images.githubusercontent.com/74687710/221717415-80af5e39-f9f4-4c53-baa2-9ecc8a97aa05.png">
